### PR TITLE
id2020 link updates

### DIFF
--- a/ThePathToSelf-SovereignIdentity.md
+++ b/ThePathToSelf-SovereignIdentity.md
@@ -1,6 +1,6 @@
 # The Path to Self-Sovereign Identity
 
-Today I head out to a month-long series of events associated with identity: I’m starting with the 22st (!) [Internet Identity Workshop](http://www.internetidentityworkshop.com/) next week; then I’m speaking at the blockchain conference [Consensus](http://www.coindesk.com/events/consensus-2016/) about identity; next I am part of the team putting together the first [ID2020 Summit](http://id2020summit.org/) on Digital Identity at the United Nations; and finally I'm hosting the second [#RebootingWebOfTrust](http://www.weboftrust.info/) design workshop on decentralized identity.
+Today I head out to a month-long series of events associated with identity: I’m starting with the 22st (!) [Internet Identity Workshop](http://www.internetidentityworkshop.com/) next week; then I’m speaking at the blockchain conference [Consensus](http://www.coindesk.com/events/consensus-2016/) about identity; next I am part of the team putting together the first [ID2020 Summit](https://www.un.org/partnerships/news/id2020-summit-2016/) on Digital Identity at the United Nations; and finally I'm hosting the second [#RebootingWebOfTrust](http://www.weboftrust.info/) design workshop on decentralized identity.
 
 At all of these events I want to share a vision for how we can enhance the ability of digital identity to enable trust while preserving individual privacy. This vision is what I call “Self-Sovereign Identity”. 
 


### PR DESCRIPTION
Origin links(http://id2020summit.org) directed to free child labour and spice importers and distributors websites. 
which we can choose to update to the new domain name (https://id2020.org/) or
the press from UN (https://www.un.org/partnerships/news/id2020-summit-2016)